### PR TITLE
Feature/intygfv 11093

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ dependencies {
     compile(kotlin("reflect", kotlinVersion))
 
     compile("se.inera.intyg.clinicalprocess.healthcond.srs:intyg-clinicalprocess-healthcond-srs-schemas:0.0.13")
-    compile("se.riv.itintegration.monitoring:itintegration-monitoring-schemas:1.0.0.4")
+    compile("se.riv.itintegration.monitoring:itintegration-monitoring-schemas:1.0.0.5")
 
     // External dependencies
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
     compile(kotlin("stdlib", kotlinVersion))
     compile(kotlin("reflect", kotlinVersion))
 
-    compile("se.inera.intyg.clinicalprocess.healthcond.srs:intyg-clinicalprocess-healthcond-srs-schemas:0.0.12")
+    compile("se.inera.intyg.clinicalprocess.healthcond.srs:intyg-clinicalprocess-healthcond-srs-schemas:0.0.13")
     compile("se.riv.itintegration.monitoring:itintegration-monitoring-schemas:1.0.0.4")
 
     // External dependencies

--- a/performanceTest/build.gradle.kts
+++ b/performanceTest/build.gradle.kts
@@ -76,8 +76,8 @@ dependencies {
     compile(kotlin("stdlib", kotlinVersion))
     compile(kotlin("reflect", kotlinVersion))
 
-    compile("se.inera.intyg.clinicalprocess.healthcond.srs:intyg-clinicalprocess-healthcond-srs-schemas:0.0.8")
-    compile("se.riv.itintegration.monitoring:itintegration-monitoring-schemas:1.0.0.4")
+    compile("se.inera.intyg.clinicalprocess.healthcond.srs:intyg-clinicalprocess-healthcond-srs-schemas:0.0.13")
+    compile("se.riv.itintegration.monitoring:itintegration-monitoring-schemas:1.0.0.5")
 
     // External dependencies
     implementation("org.springframework.boot:spring-boot-starter-web")


### PR DESCRIPTION
Jag har uppdaterat CXF och jaxb2 dependencies i alla scheman och övriga intygsprojekt. Gick in och ändrade till de senaste versionerna här också, men jag har inte testkört. Du får gärna plocka ut branchen och testa innan du mergar.

I vilket fall som helst så användes CXF 3.1.3 tidigare, och nu 3.2.4 (Kunde inte gå högre pga en feature som vi nyttjar och som de tagit bort i senare versioner)

För JAXB2 så bytte jag från 0.9.5 till 1.11.1